### PR TITLE
Improved ++/-- regexes and best/worst 

### DIFF
--- a/src/karma-classic.coffee
+++ b/src/karma-classic.coffee
@@ -12,8 +12,8 @@
 #   <thing>-- - take away some of thing's karma
 #   hubot karma <thing> - check thing's karma (if <thing> is omitted, show the top 5)
 #   hubot karma empty <thing> - empty a thing's karma
-#   hubot karma best - show the top 5
-#   hubot karma worst - show the bottom 5
+#   hubot karma best [n] - show the top n (default: 5)
+#   hubot karma worst [n] - show the bottom n (default: 5)
 #
 # Author:
 #   D. Stuart Freeman (@stuartf) https://github.com/stuartf

--- a/src/karma-classic.coffee
+++ b/src/karma-classic.coffee
@@ -76,12 +76,12 @@ class Karma
 
 module.exports = (robot) ->
   karma = new Karma robot
-  robot.hear /(\S+[^+\s])\+\+(\s|$)/, (msg) ->
+  robot.hear /@?(\S+[^+\s])\+\+(\s|$)/, (msg) ->
     subject = msg.match[1].toLowerCase()
     karma.increment subject
     msg.send "#{subject} #{karma.incrementResponse()} (Karma: #{karma.get(subject)})"
 
-  robot.hear /(\S+[^-\s])--(\s|$)/, (msg) ->
+  robot.hear /@?(\S+[^-\s])--(\s|$)/, (msg) ->
     subject = msg.match[1].toLowerCase()
     karma.decrement subject
     msg.send "#{subject} #{karma.decrementResponse()} (Karma: #{karma.get(subject)})"

--- a/src/karma-classic.coffee
+++ b/src/karma-classic.coffee
@@ -91,15 +91,21 @@ module.exports = (robot) ->
     karma.kill subject
     msg.send "#{subject} has had its karma scattered to the winds."
 
-  robot.respond /karma( best)?$/i, (msg) ->
+  robot.respond /karma best\s*(\d+)?$/i, (msg) ->
+    count = if msg.match.length > 1 then msg.match[1] else null
     verbiage = ["The Best"]
-    for item, rank in karma.top()
+    if count?
+        verbiage[0] = verbiage[0].concat(" ", count.toString()) 
+    for item, rank in karma.top(count)
       verbiage.push "#{rank + 1}. #{item.name} - #{item.karma}"
     msg.send verbiage.join("\n")
 
-  robot.respond /karma worst$/i, (msg) ->
+  robot.respond /karma worst\s*(\d+)?$/i, (msg) ->
+    count = if msg.match.length > 1 then msg.match[1] else null
     verbiage = ["The Worst"]
-    for item, rank in karma.bottom()
+    if count?
+        verbiage[0] = verbiage[0].concat(" ", count.toString()) 
+    for item, rank in karma.bottom(count)
       verbiage.push "#{rank + 1}. #{item.name} - #{item.karma}"
     msg.send verbiage.join("\n")
 

--- a/src/karma-classic.coffee
+++ b/src/karma-classic.coffee
@@ -90,8 +90,10 @@ module.exports = (robot) ->
   ###
   robot.hear /@?(\S+[^-\s])--(\s|$)/, (msg) ->
     subject = msg.match[1].toLowerCase()
-    karma.decrement subject
-    msg.send "#{subject} #{karma.decrementResponse()} (Karma: #{karma.get(subject)})"
+    # avoid catching HTML comments
+    unless subject[-2..] == "<!"
+      karma.decrement subject
+      msg.send "#{subject} #{karma.decrementResponse()} (Karma: #{karma.get(subject)})"
 
   ###
   # Listen for "karma empty x" and empty x's karma


### PR DESCRIPTION
I made a few changes for our team's Slack bot and I thought I'd see if you wanted to include them in the main package. Here's the list of what I did:
- Since Slack uses "@" for usernames, we kept having karma for both `bob` and `@bob`. I tweaked the regexes to ignore leading "@"s, so `@bob++` and `bob++` both increment `bob`
- Every time someone posted an HTML snippet with a comment, `<!--` would trigger a karma loss for `<!`. I put in a check for that so it could be ignored.
- I added an optional numeric argument to `karma best` and `karma worst`, so now you can get the top 10, 20, 100, etc. Default is still 5.
- I added some (overly-?) descriptive comments, mostly because I'm still fairly new at reading CoffeeScript.
